### PR TITLE
1.0.2 - linknacional-file-browser (Bug: Carregamento de adaptação do LiteSpeed)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: linknacional-file-browser
   PHP_VERSION: "8.2"
-  PLUGIN_VERSION: '1.0.1'
+  PLUGIN_VERSION: '1.0.2'
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: linknacional-file-browser
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.0.1"
+  DEPLOY_TAG: "1.0.2"
 
 jobs:
   deploy-to-wp:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ $this->loader->run(); // dispara todos na seq
 
 ### Constantes (`linknacional-file-browser.php`)
 ```php
-LINKNACIONAL_FILEBROWSER_VERSION       // '1.0.1'
+LINKNACIONAL_FILEBROWSER_VERSION       // '1.0.2'
 LINKNACIONAL_FILEBROWSER_PLUGIN_NAME                // 'linknacional-file-browser'
 LINKNACIONAL_FILEBROWSER_PLUGIN_URL    // plugin_dir_url(__FILE__)
 LINKNACIONAL_FILEBROWSER_PLUGIN_PATH   // plugin_dir_path(__FILE__)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.2 - 03/08/2026
+* Bug: Carregamento de adaptação do LiteSpeed.
+  
 # 1.0.1 - 03/08/2026
 * Bug: Carregamento do script do Font Awesome.
   

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: linknacional
 Tags: file manager, documents, upload, folders, download
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Requires PHP: 8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.txt
+++ b/README.txt
@@ -93,6 +93,9 @@ Yes! The plugin is built with responsive design and automatically adapts to tabl
 
 == Changelog ==
 
+= 1.0.2 - 2026-08-03 =
+* Bug: LiteSpeed adaptation loading.
+
 = 1.0.1 - 2026-08-03 =
 * Bug: Font Awesome script loading.
 

--- a/includes/LinkNacionalFilebrowser.php
+++ b/includes/LinkNacionalFilebrowser.php
@@ -64,6 +64,9 @@ class LinkNacionalFilebrowser {
 		$this->loader->add_action( 'wp_ajax_nopriv_linknacional_frontend_get_folder_files', $plugin_public, 'get_folder_files_frontend' );
 		$this->loader->add_action( 'wp_ajax_nopriv_linknacional_get_public_nonce', $plugin_public, 'linknacional_get_public_nonce');
 		$this->loader->add_action( 'wp_ajax_linknacional_get_public_nonce', $plugin_public, 'linknacional_get_public_nonce');
+
+		// Prevent LiteSpeed Cache from combining/minifying FontAwesome bundle
+		$this->loader->add_filter( 'script_loader_tag', $this, 'add_no_optimize_attr', 10, 3 );
 	}
 
 	public function run() {
@@ -80,5 +83,12 @@ class LinkNacionalFilebrowser {
 
 	public function get_version() {
 		return $this->version;
+	}
+
+	public function add_no_optimize_attr( $tag, $handle, $src ) {
+		if ( 'linknacional-filebrowser-fontawesome' === $handle ) {
+			$tag = str_replace( '<script ', '<script data-no-optimize="1" data-no-defer="1" ', $tag );
+		}
+		return $tag;
 	}
 }

--- a/includes/LinkNacionalFilebrowser.php
+++ b/includes/LinkNacionalFilebrowser.php
@@ -16,7 +16,7 @@ class LinkNacionalFilebrowser {
 		if ( defined( 'LINKNACIONAL_FILEBROWSER_VERSION' ) ) {
 			$this->version = LINKNACIONAL_FILEBROWSER_VERSION;
 		} else {
-			$this->version = '1.0.1';
+			$this->version = '1.0.2';
 		}
 		$this->plugin_name = 'linknacional-file-browser';
 

--- a/includes/LinkNacionalFilebrowserActivator.php
+++ b/includes/LinkNacionalFilebrowserActivator.php
@@ -50,6 +50,6 @@ class LinkNacionalFilebrowserActivator {
 			wp_mkdir_p( $filebrowser_dir );
 		}
 
-		\add_option( 'linknacional_filebrowser_db_version', '1.0.1' );
+		\add_option( 'linknacional_filebrowser_db_version', '1.0.2' );
 	}
 }

--- a/linknacional-file-browser.php
+++ b/linknacional-file-browser.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Link Nacional File Browser
  * Plugin URI:        https://www.linknacional.com.br
  * Description:       Create your folder structure and display it on the frontend.
- * Version:           1.0.0
+ * Version:           1.0.2
  * Requires at least: 6.0
  * Requires PHP:      8.2
  * Author:            Link Nacional
@@ -30,7 +30,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version.
  */
-define( 'LINKNACIONAL_FILEBROWSER_VERSION', '1.0.1' );
+define( 'LINKNACIONAL_FILEBROWSER_VERSION', '1.0.2' );
 define( 'LINKNACIONAL_FILEBROWSER_PLUGIN_NAME', 'linknacional-file-browser' );
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linknacional-file-browser",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "private": true,
     "scripts": {
         "build": "webpack --mode production",


### PR DESCRIPTION
# Link Nacional File Browser

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: file-browser, file-manager, documents, upload, folders

Testado até: 7.0

Versão estável: 1.0.2

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil) / Inglês

Um plugin completo de navegador de arquivos com sistema de pastas hierárquicas e interface de pesquisa para WordPress.

## Descrição

O Link Nacional File Browser é um plugin WordPress que permite criar e gerenciar um sistema de arquivos hierárquico completo. Oferece uma interface administrativa para organizar arquivos em pastas e um shortcode para exibir o navegador de arquivos no frontend.

**Principais Recursos:**

* **Sistema de Pastas Hierárquicas**: Crie pastas e subpastas organizadas como no Windows Explorer
* **Upload de Múltiplos Arquivos**: Suporte para PDF, Word, Excel, PowerPoint, imagens e mais
* **Interface de Pesquisa**: Busca rápida por arquivos e pastas no frontend
* **Visualização Responsiva**: Layout em grade ou lista adaptável a dispositivos móveis
* **Breadcrumb Navigation**: Navegação intuitiva entre pastas
* **Shortcode Flexível**: Múltiplas opções de configuração via shortcode

**Tipos de Arquivo Suportados:**
* Documentos: PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX, TXT
* Imagens: JPG, JPEG, PNG, GIF

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".

## Resumo(1.0.2):

* Bug: Carregamento de adaptação do LiteSpeed.